### PR TITLE
Fix XTTS load error under PyTorch 2.6

### DIFF
--- a/tts.py
+++ b/tts.py
@@ -1,9 +1,10 @@
 import torch
 from torch.serialization import add_safe_globals
 from TTS.tts.configs.xtts_config import XttsConfig
+from TTS.tts.models.xtts import XttsAudioConfig
 
-# Allowlist XttsConfig to avoid UnpicklingError
-add_safe_globals([XttsConfig])
+# Allowlist required config classes to avoid UnpicklingError
+add_safe_globals([XttsConfig, XttsAudioConfig])
 
 from TTS.api import TTS
 


### PR DESCRIPTION
## Summary
- allowlist `XttsAudioConfig` so xtts models load correctly with torch 2.6

## Testing
- `python -m py_compile tts.py`
- `python -m py_compile app.py chat.py stt.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68437cafc698832fa03f03d815bb70bb