### PR TITLE
Fix unpickling error with XTTS

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -33,6 +33,10 @@ torch_mock.serialization = serialization_module
 sys.modules['torch'] = torch_mock
 sys.modules['torch.serialization'] = serialization_module
 
+shared_configs_module = types.ModuleType('TTS.config.shared_configs')
+shared_configs_module.BaseDatasetConfig = MagicMock()
+sys.modules['TTS.config.shared_configs'] = shared_configs_module
+
 TTS_module = types.ModuleType('TTS')
 sys.modules['TTS'] = TTS_module
 TTS_tts = types.ModuleType('TTS.tts')

--- a/tts.py
+++ b/tts.py
@@ -2,9 +2,10 @@ import torch
 from torch.serialization import add_safe_globals
 from TTS.tts.configs.xtts_config import XttsConfig
 from TTS.tts.models.xtts import XttsAudioConfig
+from TTS.config.shared_configs import BaseDatasetConfig
 
 # Allowlist required config classes to avoid UnpicklingError
-add_safe_globals([XttsConfig, XttsAudioConfig])
+add_safe_globals([XttsConfig, XttsAudioConfig, BaseDatasetConfig])
 
 from TTS.api import TTS
 


### PR DESCRIPTION
## Summary
- support `BaseDatasetConfig` when loading XTTS
- update tests to mock the new module

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68438232e0cc832fb4c6554436e61a38