### PR TITLE
Fix TTS init for new PyTorch

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -46,6 +46,7 @@ configs_module.XttsConfig = MagicMock()
 sys.modules["TTS.tts.configs.xtts_config"] = configs_module
 models_module = types.ModuleType("TTS.tts.models.xtts")
 models_module.XttsAudioConfig = MagicMock()
+models_module.XttsArgs = MagicMock()
 sys.modules["TTS.tts.models.xtts"] = models_module
 api_module = types.ModuleType("TTS.api")
 api_module.TTS = MagicMock()

--- a/tts.py
+++ b/tts.py
@@ -1,11 +1,11 @@
 from torch.serialization import add_safe_globals
 from TTS.tts.configs.xtts_config import XttsConfig
-from TTS.tts.models.xtts import XttsAudioConfig
+from TTS.tts.models.xtts import XttsAudioConfig, XttsArgs
 from TTS.config.shared_configs import BaseDatasetConfig
 from TTS.api import TTS
 
 # Allowlist required config classes to avoid UnpicklingError
-add_safe_globals([XttsConfig, XttsAudioConfig, BaseDatasetConfig])
+add_safe_globals([XttsConfig, XttsAudioConfig, BaseDatasetConfig, XttsArgs])
 
 tts = TTS(
     model_name="tts_models/multilingual/multi-dataset/xtts_v2",


### PR DESCRIPTION
## Summary
- support `XttsArgs` during TTS model loading
- update tests for new safe global

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684386b61868832fb6d3a15705459036