### PR TITLE
Fix default CPU usage for STT and TTS

### DIFF
--- a/stt.py
+++ b/stt.py
@@ -1,6 +1,8 @@
 from faster_whisper import WhisperModel
+import torch
+device = "cuda" if torch.cuda.is_available() else "cpu"
 
-model = WhisperModel("medium", device="cuda")
+model = WhisperModel("medium", device=device)
 
 
 def transcribe(audio_path):

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -30,6 +30,7 @@ torch_mock = types.ModuleType("torch")
 serialization_module = types.ModuleType("torch.serialization")
 serialization_module.add_safe_globals = MagicMock()
 torch_mock.serialization = serialization_module
+torch_mock.cuda = types.SimpleNamespace(is_available=MagicMock(return_value=False))
 sys.modules["torch"] = torch_mock
 sys.modules["torch.serialization"] = serialization_module
 

--- a/tts.py
+++ b/tts.py
@@ -1,4 +1,5 @@
 from torch.serialization import add_safe_globals
+import torch
 from TTS.tts.configs.xtts_config import XttsConfig
 from TTS.tts.models.xtts import XttsAudioConfig, XttsArgs
 from TTS.config.shared_configs import BaseDatasetConfig
@@ -7,9 +8,11 @@ from TTS.api import TTS
 # Allowlist required config classes to avoid UnpicklingError
 add_safe_globals([XttsConfig, XttsAudioConfig, BaseDatasetConfig, XttsArgs])
 
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
 tts = TTS(
     model_name="tts_models/multilingual/multi-dataset/xtts_v2",
-).to("cuda")
+).to(device)
 
 
 def text_to_speech(text, output_path="output.wav"):


### PR DESCRIPTION
## Summary
- make the XTTS and Whisper models automatically fall back to CPU when CUDA is not available
- update tests to fake `torch.cuda.is_available`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684388e43248832f92abb4be833f3376